### PR TITLE
process_type init error for other NGX_MAX_HELPER_PROCESSES processes

### DIFF
--- a/src/ipc.h
+++ b/src/ipc.h
@@ -58,7 +58,7 @@ struct ipc_readbuf_s {
 
 typedef struct ipc_s ipc_t;
 
-typedef enum {IPC_NGX_PROCESS_WORKER, IPC_NGX_PROCESS_CACHE_MANAGER, IPC_NGX_PROCESS_CACHE_LOADER, IPC_NGX_PROCESS_UNKNOWN,  IPC_NGX_PROCESS_ANY} ipc_ngx_process_type_t;
+typedef enum {IPC_NGX_PROCESS_UNKNOWN, IPC_NGX_PROCESS_WORKER, IPC_NGX_PROCESS_CACHE_MANAGER, IPC_NGX_PROCESS_CACHE_LOADER,  IPC_NGX_PROCESS_ANY} ipc_ngx_process_type_t;
 
 typedef enum {IPC_PIPE, IPC_SOCKETPAIR} ipc_socket_type_t;
 typedef struct {


### PR DESCRIPTION
ipc_shm_data_t.process_slots[].process_type of all processes, will be IPC_NGX_PROCESS_WORKER; but it should be IPC_NGX_PROCESS_UNKNOWN if not workers.

It will lead ipc.broadcast() send two more msg!